### PR TITLE
Make exit on error more obvious.

### DIFF
--- a/V0p2_minimal_hw_compilation_tests.sh
+++ b/V0p2_minimal_hw_compilation_tests.sh
@@ -38,7 +38,7 @@ PARTPATHS="
 for pp in $PARTPATHS;
 do
     echo "@@@@@@" Testing $SKETCH_PATH/$pp
-    arduino --verify --board $BUILD_TARGET $SKETCH_PATH/$pp
+    arduino --verify --board $BUILD_TARGET $SKETCH_PATH/$pp || exit 2
 done
 
 exit 0


### PR DESCRIPTION
Note that "#!/bin/sh -e" means that this should be redundant,
but for clarity...